### PR TITLE
feat: user should be able to resend confirmation

### DIFF
--- a/__tests__/validatotrs/resend_confirm.test.js
+++ b/__tests__/validatotrs/resend_confirm.test.js
@@ -1,0 +1,58 @@
+/* eslint-disable class-methods-use-this */
+/**
+ * @jest-environment node
+ */
+import validators from '../../src/validators';
+
+class Response {
+  status(status) {
+    this.status = status;
+
+    return this;
+  }
+
+  json(data) {
+    return data;
+  }
+}
+
+describe('The login validator', () => {
+  it('should call the next function when validation succeeds', async () => {
+    const req = {
+      body: {
+        email: 'a@b.com'
+      }
+    };
+
+    const res = {};
+    const next = jest.fn();
+
+    await validators.resendConfirmEmailValidator(req, res, next);
+
+    expect(next).toHaveBeenCalled();
+  });
+
+  it('should return a 422 if validation fails', async () => {
+    const req = {
+      body: {
+        email: ''
+      }
+    };
+    const next = jest.fn();
+    const res = new Response();
+
+    const statusSpy = jest.spyOn(res, 'status');
+    const jsonSpy = jest.spyOn(res, 'json');
+
+    await validators.resendConfirmEmailValidator(req, res, next);
+    expect(statusSpy).toHaveBeenCalledWith(422);
+    expect(jsonSpy).toHaveBeenCalledWith({
+      message: 'Validation failed.',
+      data: {
+        errors: {
+          email: 'email is a required field'
+        }
+      }
+    });
+  });
+});

--- a/src/controllers/auth.js
+++ b/src/controllers/auth.js
@@ -102,8 +102,37 @@ const confirmEmail = async (req, res) => {
   }
 };
 
+/**
+   * @method resendConfirmEmail
+   * @description Method for user to resend email confirmation
+   * @param {object} req - The Request Object
+   * @param {object} res - The Response Object
+   * @returns {object} response body object
+   */
+const resendConfirmEmail = async (req, res) => {
+  try {
+    const { email } = req.body;
+    const user = await UserModel.findOne({ email });
+
+    if (!user) {
+      return errorResponse(res, status.notfound, messages.resendEmailConfirm.notfound);
+    }
+
+    if (user && user.emailConfirmedAt) {
+      return errorResponse(res, status.conflict, messages.resendEmailConfirm.conflict);
+    }
+
+    await user.sendEmailConfirmationEmail();
+
+    return successResponse(res, status.success, messages.resendEmailConfirm.success);
+  } catch (error) {
+    return errorResponse(res, status.error, messages.resendEmailConfirm.error);
+  }
+};
+
 export default {
   registerUser,
   signInUser,
-  confirmEmail
+  confirmEmail,
+  resendConfirmEmail
 };

--- a/src/routes/v1/auth.js
+++ b/src/routes/v1/auth.js
@@ -13,4 +13,7 @@ authRouter.post('/signin', validators.signinValidator, authController.signInUser
 /** Route for confirming email of an already existing user */
 authRouter.post('/emails/confirm', validators.confirmEmailValidator, authController.confirmEmail);
 
+/** Route for resending confirmation email  */
+authRouter.post('/emails/confirm/resend', validators.resendConfirmEmailValidator, authController.resendConfirmEmail);
+
 export default authRouter;

--- a/src/utils/responses.js
+++ b/src/utils/responses.js
@@ -14,6 +14,12 @@ const messages = {
   emailConfirm: {
     success: 'Email confirmed successfully',
     error: 'Error confirming email, please try again'
+  },
+  resendEmailConfirm: {
+    success: 'Email confirmation resent successfully',
+    error: 'Error resending confirmation email, please try again',
+    conflict: 'Email already confirmed please sign in',
+    notfound: 'User Cannot be found'
   }
 };
 

--- a/src/validation_schemas/index.js
+++ b/src/validation_schemas/index.js
@@ -25,8 +25,13 @@ export const ConfirmEmailSchema = Yup.object().shape({
   token: Yup.string().required()
 });
 
+export const ResendConfirmEmailSchema = Yup.object().shape({
+  email: Yup.string().email().required()
+});
+
 export default {
   RegisterSchema,
   SigninSchema,
-  ConfirmEmailSchema
+  ConfirmEmailSchema,
+  ResendConfirmEmailSchema
 };

--- a/src/validators/index.js
+++ b/src/validators/index.js
@@ -1,10 +1,12 @@
 import registerValidator from './register';
 import signinValidator from './signin';
 import confirmEmailValidator from './confirm_email';
+import resendConfirmEmailValidator from './resend_confirm';
 
 
 export default {
   registerValidator,
   signinValidator,
-  confirmEmailValidator
+  confirmEmailValidator,
+  resendConfirmEmailValidator
 };

--- a/src/validators/resend_confirm.js
+++ b/src/validators/resend_confirm.js
@@ -1,0 +1,28 @@
+import { ResendConfirmEmailSchema } from '../validation_schemas';
+
+/**
+ * Validates the login request
+ * @param {Object} req
+ * @param {Object} res
+ * @param {Function} next
+ * @return {Object}
+ */
+export default async (req, res, next) => {
+  const { email } = req.body;
+  try {
+    await ResendConfirmEmailSchema.validate({
+      email
+    });
+
+    return next();
+  } catch (error) {
+    return res.status(422).json({
+      message: 'Validation failed.',
+      data: {
+        errors: {
+          [error.path]: error.message
+        }
+      }
+    });
+  }
+};


### PR DESCRIPTION
## Description
- Created validator for  resending confirmation email,
- Created resend confirmation email method in the auth controller
- Created resend confirmation route
- Wrote unit test for validator,  and controller

Finishes #14


## How Has This Been Tested?
1. In your terminal, run `git clone https://github.com/BuildForSDG/SmeVest-Backend.git`
2. Run `cd SmeVest-Backend`
3. Run `git fetch origin ft-resend-confirm`
4. Run `git checkout origin/ft-resend-confirm`
5. Run `yarn install`
6. create a `.env` file in the root directory then add details as seen in `.env-example` file
7. Run `yarn run test` to run unit tests
8. Run `yarn run start:dev` to start the development server
7. To test with postman use `http://localhost:4000/api/v1/auth/emails/confirm/resend` with appropriate parameters,

- Sample request:
```json
{
	"email": "emails@mail.com",
}
```

- Sample success response :
 ```json
{
    "status": 200,
    "message": "Email confirmation resent successfully"
}
```
## Screenshots (if applicable, else remove this line / section)


## Checklist:
<!--- Put an `x` in all the boxes that apply ! -->
- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have added necessary inline code documentation
- [x] I have added tests that prove my fix is effective and that this feature works
- [x] New and existing unit tests pass locally with my changes
